### PR TITLE
Add VScode preset files + template modifications

### DIFF
--- a/Python/Project Templates/{{ cookiecutter.__project_name }}/.gitignore
+++ b/Python/Project Templates/{{ cookiecutter.__project_name }}/.gitignore
@@ -69,8 +69,7 @@ dmypy.json
 #.idea/
 
 ### VisualStudioCode ###
-.vscode/*
-.vscode/settings.json
+!.vscode/settings.json
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json

--- a/Python/Project Templates/{{ cookiecutter.__project_name }}/.pre-commit-config.yaml
+++ b/Python/Project Templates/{{ cookiecutter.__project_name }}/.pre-commit-config.yaml
@@ -1,22 +1,23 @@
 default_language_version:
   python: python3.10.7
+exclude: ^\.vscode/settings.json
 repos:
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     rev: v0.0.282
     hooks:
       - id: ruff
-        args: [--exit-non-zero-on-fix]
+        args: [--fix, --exit-non-zero-on-fix]
         types_or: [python, pyi, jupyter]
-  - repo: https://github.com/psf/black
-    rev: 23.7.0
-    hooks:
-      - id: black
-      - id: black-jupyter
   - repo: https://github.com/pycqa/isort
     rev: 5.12.0
     hooks:
       - id: isort
         args: ["--profile", "black", "--filter-files"]
+  - repo: https://github.com/psf/black
+    rev: 23.7.0
+    hooks:
+      - id: black
+      - id: black-jupyter
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:

--- a/Python/Project Templates/{{ cookiecutter.__project_name }}/.vscode/extensions.json
+++ b/Python/Project Templates/{{ cookiecutter.__project_name }}/.vscode/extensions.json
@@ -1,0 +1,41 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+  // Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+
+  // List of extensions which should be recommended for users of this workspace.
+  "recommendations": [
+    "Alpha4.jsonl",
+    "charliermarsh.ruff",
+    "daiyy.quick-html-previewer",
+    "DanishSarwar.reverse-search",
+    "DavidAnson.vscode-markdownlint",
+    "deerawan.vscode-dash",
+    "donjayamanne.githistory",
+    "DotJoshJohnson.xml",
+    "eamodio.gitlens",
+    "esbenp.prettier-vscode",
+    "formulahendry.code-runner",
+    "GitHub.vscode-pull-request-github",
+    "hbenl.vscode-test-explorer",
+    "jithurjacob.nbpreviewer",
+    "lehoanganh298.json-lines-viewer",
+    "littlefoxteam.vscode-python-test-adapter",
+    "matangover.mypy",
+    "maximus136.change-string-case",
+    "ms-python.black-formatter",
+    "ms-python.isort",
+    "ms-python.python",
+    "ms-toolsai.jupyter",
+    "ms-toolsai.jupyter-renderers",
+    "ms-toolsai.vscode-jupyter-cell-tags",
+    "ms-toolsai.vscode-jupyter-slideshow",
+    "ms-vscode.powershell",
+    "ms-vscode.test-adapter-converter",
+    "njpwerner.autodocstring",
+    "streetsidesoftware.code-spell-checker",
+    "usernamehw.errorlens",
+    "VisualStudioExptTeam.vscodeintellicode"
+  ],
+  // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+  "unwantedRecommendations": []
+}

--- a/Python/Project Templates/{{ cookiecutter.__project_name }}/.vscode/settings.json
+++ b/Python/Project Templates/{{ cookiecutter.__project_name }}/.vscode/settings.json
@@ -1,0 +1,63 @@
+{
+  //.....................
+  // GENERAL IDE SETTINGS
+  //.....................
+  "files.autoSave": "off",
+  "editor.bracketPairColorization.independentColorPoolPerBracketType": false,
+  "editor.minimap.renderCharacters": false,
+  "editor.rulers": [88],
+  "files.insertFinalNewline": true,
+  "files.trimFinalNewlines": true,
+  "files.trimTrailingWhitespace": true,
+  "search.showLineNumbers": true,
+  "testing.automaticallyOpenPeekView": "failureAnywhere",
+  "terminal.integrated.copyOnSelection": true,
+  "terminal.integrated.env.osx": {
+    "PYTHONPATH": "${env:PYTHONPATH}:${workspaceFolder}/{{ cookiecutter.__package_name }}"
+  },
+  "terminal.integrated.env.linux": {
+    "PYTHONPATH": "${env:PYTHONPATH}:${workspaceFolder}/{{ cookiecutter.__package_name }}"
+  },
+  "terminal.integrated.env.windows": {
+    "PYTHONPATH": "${env:PYTHONPATH};${workspaceFolder}\\{{ cookiecutter.__package_name }}"
+  },
+  "terminal.integrated.defaultProfile.windows": "PowerShell",
+  "notebook.formatOnCellExecution": true,
+  "notebook.outline.showCodeCells": true,
+  "notebook.lineNumbers": "on",
+  //...................
+  // EXTENSION SETTINGS
+  //...................
+  "black-formatter.importStrategy": "fromEnvironment",
+  "cSpell.suggestionMenuType": "quickFix",
+  "css.format.spaceAroundSelectorSeparator": true,
+  "dash.exactDocset": true,
+  "git.autofetch": true,
+  "git.closeDiffOnOperation": true,
+  "git.confirmSync": false,
+  "git.openAfterClone": "whenNoFolderOpen",
+  "gitlens.showWelcomeOnInstall": true,
+  "gitlens.views.commits.files.layout": "tree",
+  "html.format.templating": true,
+  "html.format.indentInnerHtml": true,
+  "isort.check": true,
+  "isort.importStrategy": "fromEnvironment",
+  "jupyter.showVariableViewWhenDebugging": true,
+  "markdown.updateLinksOnFileMove.enabled": "prompt",
+  "merge-conflict.autoNavigateNextConflict.enabled": true,
+  "mypy.debugLogging": true,
+  "mypy.runUsingActiveInterpreter": true,
+  "powershell.codeFormatting.useConstantStrings": true,
+  "python.defaultInterpreterPath": "${workspaceFolder}/.venv/Scripts/python.exe",
+  "python.autoComplete.extraPaths": [
+    "${workspaceFolder}/data",
+    "${workspaceFolder}/config",
+    "${workspaceFolder}/tests",
+    "${workspaceFolder}/{{ cookiecutter.__package_name }}"
+  ],
+  "python.terminal.activateEnvironment": true,
+  "python.terminal.activateEnvInCurrentTerminal": true,
+  "python.testing.cwd": "./tests",
+  "python.testing.pytestEnabled": true,
+  "pythonTestExplorer.testFramework": "pytest"
+}

--- a/Python/Project Templates/{{ cookiecutter.__project_name }}/README.md
+++ b/Python/Project Templates/{{ cookiecutter.__project_name }}/README.md
@@ -14,6 +14,7 @@
 - [Setting up the Project Environment](#setting-up-the-project-environment)
 - [Installing Static Code Analysis Tools](#installing-static-code-analysis-tools)
 - [Scripts and Executables](#scripts-and-executables)
+- [VSCode Presets](#vscode-presets)
 
 ## Setting up the Project Environment
 
@@ -68,3 +69,9 @@ A set of pre-defined command line scripts have been configured to be used with {
 #### create-task
 
 Create a task within Windows Task Scheduler for running a python script that's in the package root directory of {{ cookiecutter.__package_name }}. Run the following command for more details: `poetry run create-task --help`
+
+### VSCode Presets
+
+Included in the root of {{ cookiecutter.__project_name }} is a `.vscode` folder that contains VSCode files with predefined settings. Recommended VSCode extensions are also included that can be installed for a more tailored development experience for this project. When this workspace is opened for the first time, VSCode will prompt to install the recommended extensions. You can also review this list through **Extensions -> Show Recommended Extensions command**.
+
+> Note: Workspace settings override user settings.

--- a/Python/Project Templates/{{ cookiecutter.__project_name }}/pyproject.toml
+++ b/Python/Project Templates/{{ cookiecutter.__project_name }}/pyproject.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/{{ cookiecutter.github_username }}/{{ cookiecut
 license = "{{ cookiecutter.license }}"
 packages = [
     { include = "{{ cookiecutter.__package_name }}" },
-    { include = "tests"},
+    { include = "tests" },
 ]
 
 [tool.poetry.dependencies]
@@ -75,7 +75,7 @@ show_error_context = "True"
 
 [tool.ruff]
 # The directories to consider/allow import relative to the project root directory.
-src = ["test"]
+src = ["test", "{{ cookiecutter.__package_name }}"]
 
 # A list of rule codes or prefixes to enable
 # Vist link to get more info on rules: https://beta.ruff.rs/docs/rules/


### PR DESCRIPTION
Added a preset files specific to project template.
- settings.json includes settings for recommended extensions and general IDE settings related to general actions and directory references.
- extension.json includes recommended VSCode extensions tailored to project template experience.
- Updated settings for pre-commit to exclude vscode preset files.
- Updated project.toml to include references to package name that's defined in cookiecutter deployment process.